### PR TITLE
Change codeblock in README.md to install python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These instructions will [do something] on your local machine for [development/ex
 ```
 sudo apt update
 sudo apt upgrade
-sudo apt install package1 package2
+sudo apt install python3
 ```
 
 ## Running


### PR DESCRIPTION
The main branch currently has a codeblock which has a user install package1 and package2 using apt. These packages do not exist, and based on the work, it is clear that the user needs to install Python3. I have changed the readme to reflect the need to install Python3 instead of templated package names.